### PR TITLE
rename a local variable

### DIFF
--- a/liborbum/src/Controller/Iop/Sio0/CSio0.cpp
+++ b/liborbum/src/Controller/Iop/Sio0/CSio0.cpp
@@ -107,7 +107,7 @@ void CSio0::handle_irq_check()
     // Raise IOP INTC IRQ if requested.
     if (stat.extract_field(Sio0Register_Stat::IRQ))
     {
-        auto _stat_lock = r.iop.intc.stat.scope_lock();
+        auto _stat_lock_sub = r.iop.intc.stat.scope_lock();
         r.iop.intc.stat.insert_field(IopIntcRegister_Stat::SIO0, 1);
     }
 }


### PR DESCRIPTION
Hi all,
There a renamed vairable issue found by Qihoo360 CodeSafe Team.
Details as bellow:

the name of local variable '_stat_lock' declared in line 110 is the same as the variable declared in line 94.

Cheers
Qihoo360 CodeSafe Team